### PR TITLE
Wait for all selectors to be available in V1 code

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add minified code below via these instructions.
 ##V1 CODE ([src_v1.js](https://github.com/circAssimilate/Optimizely-Poll-For-Delayed-Content/blob/master/src_v1.js)):
 This code uses CSS stylesheets to hide elements before they are added to the page and recursive timeout polling to detect, change and unhide elements after they are added. This code is in the process of being revamped as polling is less performant that DOM Mutation Observers.
 
-####COMPRESSED V1 CODE:
+###COMPRESSED V1 CODE:
 ```
 /* pollForDelayedContent function v1.1.0 */
 /* _optimizely_evaluate=force */

--- a/README.md
+++ b/README.md
@@ -1,39 +1,33 @@
 #OPTIMIZELY WAIT FOR DELAYED CONTENT
 
-The waitForDelayedContent() and pollForDelayedContent() helper functions are an alternative solution to some of the approaches listed here: https://help.optimizely.com/hc/en-us/articles/200457495.  
+The pollForDelayedContent() is a simple, efficient way to wait for dynamic content. It can be used with platforms like Optimizely, which alter dynamically created web content. Read more [here](https://help.optimizely.com/Troubleshoot_Problems/Fix_a_timing_issue).
 
-It will be able to be used as many times as it's needed within an experiment or variation. When the Optimizely snippet is implemented correctly, it should provide a way to eliminate all content flashing.
+These methods can be used as many times as they are needed within an experiment or variation. When the Optimizely snippet is implemented correctly, it should provide a way to eliminate all content flashing.
 The function allows for a an "options" element, to allow for more flexibility as well.
-Feel free to file a ticket at optimizely.com/support with any feedback or questions - as the comments on this page will not be responded to.
-
-##V2 CODE ([src_v2.js](https://github.com/circAssimilate/Optimizely-Poll-For-Delayed-Content/blob/master/src_v2.js)):
-By default, the code below will detect whether or not the browser allows for DOM Mutation Observers, and use that performance efficient way to hide and change page elements.
-If DOM Mutation Observers aren't available, the code will fallback to recursive timeout polling. This is less performant and uses a recursive JavaScript setTimeout().
-
-###USAGE EXAMPLE:
-While this code is in it's early stages, see bottom of [src_v2.js](https://github.com/circAssimilate/Optimizely-Poll-For-Delayed-Content/blob/master/src_v2.js) for that.
+While *Optimizely does not officially support or maintain this custom code*, feel free to file a ticket at optimizely.com/support with any feedback or questions.
 
 ###CONTRIBUTING TO THIS REPOSITORY:
-The issues are listed directly within the src_v2.js comments. Feel free to branch and edit as desired, updating those as you go.
+When contributing and changing the core code, please update this Readme, the compressed code and "UNCOMPRESSED CODE" sections. You can compress via http://jscompress.com/ and replace the minified code.
 
-###V2 PARAMETER CONTEXT:
-```
-@param {String} selectorToChange - The single element you want to change and hide *
-@param {Function} changeFn - The code, passed in through a funtion that you want to run when the "selector" is found - (e.g. function(){$("body > h1.header-image").html("New Header"); $("body > h1.header-image").css("color", "#0081ba");})
-@param {Object} options - (optional) The elements you want to change and hide
-@param {Boolean} options.repeat - (optional) When set to true, this code will continue to modify new page elements that match the selectorToChange paramter. This works best for browsers that support DOM Mutation Observers, but can also work with the recursive timeout polling.
-@param {Integer} options.timeoutInSeconds - (optional) Time in seconds this function will take to "timeout" or stop trying. If this argument is not specified, the interval will not timeout - (e.g. 2)
-@param {String} options.selectorToHide - (optional)  The element to hide until the delayed element is changed.
-@param {Integer} options.unhideDelayInMilliseconds - (optional) Time in milliseconds before selectorToChange (or options.selectorToHide if provided) is unhidden - after changeFn runs. If this argument is not specified, the timeout is 0 - (e.g. 500)
-@param {Integer} options.pollingIntervalInMilliseconds - (optional) Time in milliseconds between interval polls for "selector" when using the recursive timeout polling option. If this argument is not specified, the interval poll will be set up 50 milliseconds - (e.g. 100)
-@param {String} options.method - (optional) If "POLL", recursive timeout polling will be used, overriding the default functionality. If not provided, the code will default to using DOM Mutation Observers if available in the browser and fallback on recursive timeout polling.
-```
+###IMPLEMENTATION INSTRUCTIONS:
+Add minified code below via these instructions.
+
+- The minified code can either be added to Experiment JS or Project JS (for Enterprise subscriptions)
+- If you place it in Experiment JS, you must add the pollForDelayedContent() function definition within the `_optimizely_evaluate=force` comments
+- You can then call the window.pollForDelayedContent() function as many times as neceesary within the experiment variation's "< edit code >" section
+- The window.pollForDelayedContent() function in the "< edit code >" section must also be wrapped in the `_optimizely_evaluate=force` comments
+- [Optiverse info](https://help.optimizely.com/hc/en-us/articles/200040185-Force-variation-code-or-Experiment-JavaScript-to-execute-immediately-when-Optimizely-loads) on `_optimizely_evaluate=force` comments.
 
 ##V1 CODE ([src_v1.js](https://github.com/circAssimilate/Optimizely-Poll-For-Delayed-Content/blob/master/src_v1.js)):
 This code uses CSS stylesheets to hide elements before they are added to the page and recursive timeout polling to detect, change and unhide elements after they are added. This code is in the process of being revamped as polling is less performant that DOM Mutation Observers.
 
-###CONTRIBUTING TO THIS REPOSITORY:
-For parity, when contributing and changing the core "UNCOMPRESSED CODE", please compress via http://jscompress.com/ and replace the minified code.
+####COMPRESSED V1 CODE:
+```
+/* pollForDelayedContent function v1.1.0 */
+/* _optimizely_evaluate=force */
+window.pollForDelayedContent=function(a,b,c){var d=+new Date,e=50;c=c||{};var f=c.selectorToHide||a,g=c.unhideDelayInMilliseconds||0,h=1e3*c.timeoutInSeconds||null,i=c.intervalInMilliseconds||e,j=function(a){var b="optlyHide_"+ +new Date;return $("head").prepend("<style id='"+b+"' type='text/css'>"+a+" {visibility:hidden !important;}</style>"),function(){$("#"+b).remove()}},k=j(f),l=function(){b(),setTimeout(k,g)},m=function(){var b=+new Date;$(a).length>=a.split(",").length?l():h&&b-d>h?k():setTimeout(m,i)};m()};
+/* _optimizely_evaluate=safe */
+```
 
 ###SIMPLE USAGE EXAMPLE:
 This does not use the optional options object to specify selectorToHide, timeoutInSeconds, or intervalInMilliseconds, causing them to default to hide the no timeout and 50 milliseconds.
@@ -75,11 +69,20 @@ window.pollForDelayedContent("body > h1.header-image", function() {
 @param {Integer} options.intervalInMilliseconds - (optional) Time in milliseconds between interval polls for "selector". If this argument is not specified, the interval poll will be set up 50 milliseconds - (e.g. 100)
 ```
 
-###IMPLEMENTATION INSTRUCTIONS:
-Add minified code below via these instructions.
+##V2 CODE ([src_v2.js](https://github.com/circAssimilate/Optimizely-Poll-For-Delayed-Content/blob/master/src_v2.js)):
+By default, the code below will detect whether or not the browser allows for DOM Mutation Observers, and use that performance efficient way to hide and change page elements.
+If DOM Mutation Observers aren't available, the code will fallback to recursive timeout polling. This is less performant and uses a recursive JavaScript setTimeout().
 
-- The minified code can either be added to Experiment JS or Project JS (for Enterprise subscriptions)
-- If you place it in Experiment JS, you must add the pollForDelayedContent() function definition within the `_optimizely_evaluate=force` comments
-- You can then call the window.pollForDelayedContent() function as many times as neceesary within the experiment variation's "< edit code >" section
-- The window.pollForDelayedContent() function in the "< edit code >" section must also be wrapped in the `_optimizely_evaluate=force` comments
-- Optiverse info on `_optimizely_evaluate=force` comments - https://help.optimizely.com/hc/en-us/articles/200040185-Force-variation-code-or-Experiment-JavaScript-to-execute-immediately-when-Optimizely-loads
+
+###V2 PARAMETER CONTEXT:
+```
+@param {String} selectorToChange - The single element you want to change and hide *
+@param {Function} changeFn - The code, passed in through a funtion that you want to run when the "selector" is found - (e.g. function(){$("body > h1.header-image").html("New Header"); $("body > h1.header-image").css("color", "#0081ba");})
+@param {Object} options - (optional) The elements you want to change and hide
+@param {Boolean} options.repeat - (optional) When set to true, this code will continue to modify new page elements that match the selectorToChange paramter. This works best for browsers that support DOM Mutation Observers, but can also work with the recursive timeout polling.
+@param {Integer} options.timeoutInSeconds - (optional) Time in seconds this function will take to "timeout" or stop trying. If this argument is not specified, the interval will not timeout - (e.g. 2)
+@param {String} options.selectorToHide - (optional)  The element to hide until the delayed element is changed.
+@param {Integer} options.unhideDelayInMilliseconds - (optional) Time in milliseconds before selectorToChange (or options.selectorToHide if provided) is unhidden - after changeFn runs. If this argument is not specified, the timeout is 0 - (e.g. 500)
+@param {Integer} options.pollingIntervalInMilliseconds - (optional) Time in milliseconds between interval polls for "selector" when using the recursive timeout polling option. If this argument is not specified, the interval poll will be set up 50 milliseconds - (e.g. 100)
+@param {String} options.method - (optional) If "POLL", recursive timeout polling will be used, overriding the default functionality. If not provided, the code will default to using DOM Mutation Observers if available in the browser and fallback on recursive timeout polling.
+```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The pollForDelayedContent() is a simple, efficient way to wait for dynamic conte
 
 These methods can be used as many times as they are needed within an experiment or variation. When the Optimizely snippet is implemented correctly, it should provide a way to eliminate all content flashing.
 The function allows for a an "options" element, to allow for more flexibility as well.
-While *Optimizely does not officially support or maintain this custom code*, feel free to file a ticket at optimizely.com/support with any feedback or questions.
+While **Optimizely does not officially support or maintain this custom code**, feel free to file a ticket at optimizely.com/support with any feedback or questions.
 
 ###CONTRIBUTING TO THIS REPOSITORY:
 When contributing and changing the core code, please update this Readme, the compressed code and "UNCOMPRESSED CODE" sections. You can compress via http://jscompress.com/ and replace the minified code.
@@ -18,10 +18,13 @@ Add minified code below via these instructions.
 - The window.pollForDelayedContent() function in the "< edit code >" section must also be wrapped in the `_optimizely_evaluate=force` comments
 - [Optiverse info](https://help.optimizely.com/hc/en-us/articles/200040185-Force-variation-code-or-Experiment-JavaScript-to-execute-immediately-when-Optimizely-loads) on `_optimizely_evaluate=force` comments.
 
-##V1 CODE ([src_v1.js](https://github.com/circAssimilate/Optimizely-Poll-For-Delayed-Content/blob/master/src_v1.js)):
+##V1 CODE:
 This code uses CSS stylesheets to hide elements before they are added to the page and recursive timeout polling to detect, change and unhide elements after they are added. This code is in the process of being revamped as polling is less performant that DOM Mutation Observers.
 
-###COMPRESSED V1 CODE:
+###UNCOMPRESSED CODE:
+View *src_v1.js* for this.
+
+###COMPRESSED CODE:
 ```
 /* pollForDelayedContent function v1.1.0 */
 /* _optimizely_evaluate=force */
@@ -69,10 +72,15 @@ window.pollForDelayedContent("body > h1.header-image", function() {
 @param {Integer} options.intervalInMilliseconds - (optional) Time in milliseconds between interval polls for "selector". If this argument is not specified, the interval poll will be set up 50 milliseconds - (e.g. 100)
 ```
 
-##V2 CODE ([src_v2.js](https://github.com/circAssimilate/Optimizely-Poll-For-Delayed-Content/blob/master/src_v2.js)):
+##V2 CODE
 By default, the code below will detect whether or not the browser allows for DOM Mutation Observers, and use that performance efficient way to hide and change page elements.
 If DOM Mutation Observers aren't available, the code will fallback to recursive timeout polling. This is less performant and uses a recursive JavaScript setTimeout().
 
+###UNCOMPRESSED CODE:
+View *src_v2.js* for this.
+
+###COMPRESSED CODE:
+View *src_v2.js* for this.
 
 ###V2 PARAMETER CONTEXT:
 ```

--- a/src_v1.js
+++ b/src_v1.js
@@ -1,5 +1,5 @@
 /**
- * V1 CODE:
+ * V1.1.0 CODE:
  *
  * This code uses CSS stylesheets to hide elements before they are added to the page and recursive timeout polling to detect, change and unhide elements after they are added.
  * This code is in the process of being revamped as polling is less performant that DOM Mutation Observers.
@@ -54,14 +54,16 @@
  * Optiverse info on "_optimizely_evaluate=force" comments - https://help.optimizely.com/hc/en-us/articles/200040185-Force-variation-code-or-Experiment-JavaScript-to-execute-immediately-when-Optimizely-loads
  */
 
+ /* pollForDelayedContent function v1.1.0 */
 /* _optimizely_evaluate=force */
-window.pollForDelayedContent=function(e,n,t){var i=+new Date,o=50;t=t||{};var l=t.selectorToHide||e,d=t.unhideDelayInMilliseconds||0,s=1e3*t.timeoutInSeconds||null,a=t.intervalInMilliseconds||o,r=function(e){var n="optlyHide_"+ +new Date;return $("head").prepend("<style id='"+n+"' type='text/css'>"+e+" {visibility:hidden !important;}</style>"),function(){$("#"+n).remove()}},u=r(l),c=function(){n(),setTimeout(u,d)},v=function(){var n=+new Date;$(e).length?c():s&&n-i>s?u():setTimeout(v,a)};v()};
+window.pollForDelayedContent=function(a,b,c){var d=+new Date,e=50;c=c||{};var f=c.selectorToHide||a,g=c.unhideDelayInMilliseconds||0,h=1e3*c.timeoutInSeconds||null,i=c.intervalInMilliseconds||e,j=function(a){var b="optlyHide_"+ +new Date;return $("head").prepend("<style id='"+b+"' type='text/css'>"+a+" {visibility:hidden !important;}</style>"),function(){$("#"+b).remove()}},k=j(f),l=function(){b(),setTimeout(k,g)},m=function(){var b=+new Date;$(a).length>=a.split(",").length?l():h&&b-d>h?k():setTimeout(m,i)};m()};
 /* _optimizely_evaluate=safe */
 
 /*
  * UNCOMPRESSED CODE - Using the minified code is recommended; but, please add via the instructions above.
  */
 
+/* pollForDelayedContent function v1.1.0 */
 /* _optimizely_evaluate=force */
 window.pollForDelayedContent = function(selectorToChange, changeFn, options) {
   /* Default info for polling */
@@ -84,9 +86,10 @@ window.pollForDelayedContent = function(selectorToChange, changeFn, options) {
     changeFn();
     setTimeout(unhideContent, unhideDelay);
   }
+
   var pollForElement = function () {
     var now = (+new Date());
-    if ($(selectorToChange).length) {
+    if ($(selectorToChange).length >= selectorToChange.split(',').length) {
       changeContent();
     } else if (timeout && now - START_TIME > timeout) {
       unhideContent();

--- a/src_v1.js
+++ b/src_v1.js
@@ -54,7 +54,7 @@
  * Optiverse info on "_optimizely_evaluate=force" comments - https://help.optimizely.com/hc/en-us/articles/200040185-Force-variation-code-or-Experiment-JavaScript-to-execute-immediately-when-Optimizely-loads
  */
 
- /* pollForDelayedContent function v1.1.0 */
+/* pollForDelayedContent function v1.1.0 */
 /* _optimizely_evaluate=force */
 window.pollForDelayedContent=function(a,b,c){var d=+new Date,e=50;c=c||{};var f=c.selectorToHide||a,g=c.unhideDelayInMilliseconds||0,h=1e3*c.timeoutInSeconds||null,i=c.intervalInMilliseconds||e,j=function(a){var b="optlyHide_"+ +new Date;return $("head").prepend("<style id='"+b+"' type='text/css'>"+a+" {visibility:hidden !important;}</style>"),function(){$("#"+b).remove()}},k=j(f),l=function(){b(),setTimeout(k,g)},m=function(){var b=+new Date;$(a).length>=a.split(",").length?l():h&&b-d>h?k():setTimeout(m,i)};m()};
 /* _optimizely_evaluate=safe */


### PR DESCRIPTION
Updated V1 function to wait for all selectors if multiple selectors are provided to the `selectorToChange` argument.